### PR TITLE
Add get_status() to the ClientUtils

### DIFF
--- a/client_utils/client_utils/base_client.py
+++ b/client_utils/client_utils/base_client.py
@@ -101,3 +101,15 @@ class BaseClient:
         """
         url = 'config'
         return await self._get(url)
+    
+    async def get_status(self) -> dict:
+        """
+        Gets the status of the STH.
+
+        Returns
+        -----------
+        dict:
+            Dict with cpm info.
+        """
+        url = 'status'
+        return await self._get(url)


### PR DESCRIPTION
**[This method from js-api-client](https://github.com/scramjetorg/transform-hub/blob/devel/packages/api-client/src/host-client.ts#L150)** was missing in the Python version.